### PR TITLE
LB backend pool support for Azure NIC module

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -6,12 +6,13 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from azure.mgmt.network.v2015_06_15.models.load_balancer import LoadBalancer
 __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'certified'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = '''
@@ -33,6 +34,11 @@ options:
         description:
             - Name of a resource group where the network interface exists or will be created.
         required: true
+    subnet_resource_group:
+        description:
+            - Name of a resource group where the subnet exists.
+        required: false
+        default: resource_group
     name:
         description:
             - Name of the network interface.
@@ -67,6 +73,17 @@ options:
             - subnet
         required: true
         default: null
+    load_balancer:
+        description:
+            - Name of an existing load balancer. Required when creating a load balancer backend address pool.
+        required: false
+        default: null
+    load_balancer_backend_pool:
+        description:
+            - Name of an existing backend pool within the specified load balancer. Required when creating a 
+              load balancer address pool.
+        required: false
+        default: null        
     os_type:
         description:
             - Determines any rules to be added to a default security group. When creating a network interface, if no
@@ -137,9 +154,20 @@ extends_documentation_fragment:
 author:
     - "Chris Houseknecht (@chouseknecht)"
     - "Matt Davis (@nitzmahone)"
+    - "Xiaoming Zheng(@siaomingjeng)"
 '''
 
 EXAMPLES = '''
+    - name: Create a network interface in a resource_group with the subnet from a different resource group and a load balancer backend pool.
+      azure_rm_networkinterface:
+            name: nic001
+            resource_group: Testing
+            subnet_resource_group: Testing2
+            virtual_network_name: vnet001
+            subnet_name: subnet001
+            load_balancer: loadbalancer001
+            load_balancer_backend_pool: backend001
+
     - name: Create a network interface with minimal parameters
       azure_rm_networkinterface:
             name: nic001
@@ -203,6 +231,9 @@ state:
                 "id": "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/publicIPAddresses/publicip001",
                 "name": "publicip001"
             },
+            "load_balancer_pool": {
+                "id": "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/loadBalancers/loadbalancer001/backendAddressPools/backend001",
+            },
             "subnet": {}
         },
         "location": "eastus2",
@@ -219,7 +250,7 @@ state:
 try:
     from msrestazure.azure_exceptions import CloudError
     from azure.mgmt.network.models import NetworkInterface, NetworkInterfaceIPConfiguration, Subnet, \
-                                          PublicIPAddress, NetworkSecurityGroup
+                                          PublicIPAddress, NetworkSecurityGroup, BackendAddressPool
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -241,6 +272,7 @@ def nic_to_dict(nic):
             private_ip_allocation_method=nic.ip_configurations[0].private_ip_allocation_method,
             subnet=dict(),
             public_ip_address=dict(),
+            load_balancer_pool=dict(),  ##
         ),
         dns_settings=dict(
             dns_servers=nic.dns_settings.dns_servers,
@@ -272,7 +304,14 @@ def nic_to_dict(nic):
             nic.ip_configurations[0].public_ip_address.id
         id_keys = azure_id_to_dict(nic.ip_configurations[0].public_ip_address.id)
         result['ip_configuration']['public_ip_address']['name'] = id_keys['publicIPAddresses']
-
+    
+    if nic.ip_configurations[0].load_balancer_backend_address_pools:
+        result['ip_configuration']['load_balancer_pool']['id'] = \
+            nic.ip_configurations[0].load_balancer_backend_address_pools[0].id
+        id_keys = azure_id_to_dict(nic.ip_configurations[0].load_balancer_backend_address_pools[0].id)
+        result['ip_configuration']['load_balancer_pool']['Loadbalancer'] = id_keys['loadBalancers']
+        result['ip_configuration']['load_balancer_pool']['backend_pool_name'] = id_keys['backendAddressPools']
+    
     return result
 
 
@@ -282,6 +321,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             resource_group=dict(type='str', required=True),
+            subnet_resource_group=dict(type='str'),
             name=dict(type='str', required=True),
             location=dict(type='str'),
             security_group_name=dict(type='str', aliases=['security_group']),
@@ -295,14 +335,19 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             os_type=dict(type='str', choices=['Windows', 'Linux'], default='Linux'),
             open_ports=dict(type='list'),
             public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
+            load_balancer=dict(type='str'),
+            load_balancer_backend_pool=dict(type='str'),
         )
 
         self.resource_group = None
+        self.subnet_resource_group = None
         self.name = None
         self.location = None
         self.security_group_name = None
         self.private_ip_address = None
         self.private_ip_allocation_method = None
+        self.load_balancer = None
+        self.load_balancer_backend_pool = None 
         self.public_ip_address_name = None
         self.state = None
         self.subnet_name = None
@@ -333,8 +378,10 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         subnet = None
         nsg = None
         pip = None
+        lbpool = None
 
         resource_group = self.get_resource_group(self.resource_group)
+        subnet_resource_group = self.get_resource_group(self.subnet_resource_group) if self.subnet_resource_group else resource_group
         if not self.location:
             # Set default location
             self.location = resource_group.location
@@ -354,11 +401,13 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
             if self.security_group_name:
                 nsg = self.get_security_group(self.security_group_name)
+                
+            if  self.load_balancer and self.load_balancer_backend_pool:  ##
+                lbpool = self.get_load_balancer_backend_pool(self.load_balancer, self.load_balancer_backend_pool)  ##
 
         try:
             self.log('Fetching network interface {0}'.format(self.name))
             nic = self.network_client.network_interfaces.get(self.resource_group, self.name)
-
             self.log('Network interface {0} exists'.format(self.name))
             self.check_provisioning_state(nic, self.state)
             results = nic_to_dict(nic)
@@ -405,6 +454,14 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                         results['ip_configuration']['subnet']['id'] = subnet.id
                         results['ip_configuration']['subnet']['name'] = subnet.name
                         results['ip_configuration']['subnet']['virtual_network_name'] = self.virtual_network_name
+                        
+
+                if self.load_balancer and self.load_balancer_backend_pool:  ##
+                    if results['ip_configuration']['load_balancer_pool'].get('id') != lbpool.id:
+                        changed = True
+                        self.log("CHANGED: network interface {0} load_balancer backend pool".format(self.name))
+                        results['ip_configuration']['load_balancer_pool']['id'] = lbpool.id
+                        
 
             elif self.state == 'absent':
                 self.log("CHANGED: network interface {0} exists but requested state is 'absent'".format(self.name))
@@ -456,6 +513,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     #nic.name = self.name
                     nic.ip_configurations[0].subnet = Subnet(id=subnet.id)
                     nic.ip_configurations[0].name = 'default'
+                    # add load balancer backend address pools
+                    if lbpool:
+                        nic.ip_configurations[0].load_balancer_backend_address_pools = [lbpool]
                     nic.network_security_group = NetworkSecurityGroup(id=nsg.id,
                                                                       location=nsg.location,
                                                                       resource_guid=nsg.resource_guid)
@@ -484,8 +544,10 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                                              results['ip_configuration']['subnet']['name'])
                     nic.ip_configurations[0].subnet = Subnet(id=subnet.id)
                     nic.ip_configurations[0].name = results['ip_configuration']['name']
-                    #nic.name = name=results['name'],
+                    if results['ip_configuration'].get('load_balancer_pool'):
+                        nic.ip_configurations[0].load_balancer_backend_address_pools = [lbpool]  ##
 
+                    #nic.name = name=results['name'],
                     if results['ip_configuration'].get('private_ip_address'):
                         nic.ip_configurations[0].private_ip_address = results['ip_configuration']['private_ip_address']
 
@@ -546,7 +608,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
     def get_subnet(self, vnet_name, subnet_name):
         self.log("Fetching subnet {0} in virtual network {1}".format(subnet_name, vnet_name))
         try:
-            subnet = self.network_client.subnets.get(self.resource_group, vnet_name, subnet_name)
+            subnet = self.network_client.subnets.get(self.subnet_resource_group, vnet_name, subnet_name)
         except Exception as exc:
             self.fail("Error: fetching subnet {0} in virtual network {1} - {2}".format(subnet_name,
                                                                                       vnet_name,
@@ -561,6 +623,15 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             self.fail("Error: fetching network security group {0} - {1}.".format(name, str(exc)))
         return nsg
 
+    def get_load_balancer_backend_pool(self, load_balancer, load_balancer_backend_pool):
+        self.log("Fetching load balancer names {0}-{1}".format(load_balancer, load_balancer_backend_pool))
+        lb_pool_id = ''
+        try:
+            lb_pool_id = self.network_client.load_balancer_backend_address_pools.get(self.resource_group, load_balancer, load_balancer_backend_pool).id
+            lbpool = BackendAddressPool(id=lb_pool_id)
+        except Exception as exc:
+            self.fail("Error: creating load balancer backend {0} - {1}.".format(pool, str(exc)))
+        return lbpool
 
 def main():
     AzureRMNetworkInterface()

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -6,7 +6,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from azure.mgmt.network.v2015_06_15.models.load_balancer import LoadBalancer
 __metaclass__ = type
 
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2016 Matt Davis, <mdavis@ansible.com>
 #                    Chris Houseknecht, <house@redhat.com>
+#                    Xiaoming Zheng, <xiaoming.zheng@icloud.com>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -79,10 +80,10 @@ options:
         default: null
     load_balancer_backend_pool:
         description:
-            - Name of an existing backend pool within the specified load balancer. Required when creating a 
+            - Name of an existing backend pool within the specified load balancer. Required when creating a
               load balancer address pool.
         required: false
-        default: null        
+        default: null
     os_type:
         description:
             - Determines any rules to be added to a default security group. When creating a network interface, if no
@@ -231,7 +232,8 @@ state:
                 "name": "publicip001"
             },
             "load_balancer_pool": {
-                "id": "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/loadBalancers/loadbalancer001/backendAddressPools/backend001",
+                "id": "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/\
+                      loadBalancers/loadbalancer001/backendAddressPools/backend001",
             },
             "subnet": {}
         },
@@ -249,7 +251,7 @@ state:
 try:
     from msrestazure.azure_exceptions import CloudError
     from azure.mgmt.network.models import NetworkInterface, NetworkInterfaceIPConfiguration, Subnet, \
-                                          PublicIPAddress, NetworkSecurityGroup, BackendAddressPool
+        PublicIPAddress, NetworkSecurityGroup, BackendAddressPool
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -271,7 +273,7 @@ def nic_to_dict(nic):
             private_ip_allocation_method=nic.ip_configurations[0].private_ip_allocation_method,
             subnet=dict(),
             public_ip_address=dict(),
-            load_balancer_pool=dict(),  ##
+            load_balancer_pool=dict(),  # #
         ),
         dns_settings=dict(
             dns_servers=nic.dns_settings.dns_servers,
@@ -303,14 +305,14 @@ def nic_to_dict(nic):
             nic.ip_configurations[0].public_ip_address.id
         id_keys = azure_id_to_dict(nic.ip_configurations[0].public_ip_address.id)
         result['ip_configuration']['public_ip_address']['name'] = id_keys['publicIPAddresses']
-    
+
     if nic.ip_configurations[0].load_balancer_backend_address_pools:
         result['ip_configuration']['load_balancer_pool']['id'] = \
             nic.ip_configurations[0].load_balancer_backend_address_pools[0].id
         id_keys = azure_id_to_dict(nic.ip_configurations[0].load_balancer_backend_address_pools[0].id)
         result['ip_configuration']['load_balancer_pool']['Loadbalancer'] = id_keys['loadBalancers']
         result['ip_configuration']['load_balancer_pool']['backend_pool_name'] = id_keys['backendAddressPools']
-    
+
     return result
 
 
@@ -346,7 +348,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         self.private_ip_address = None
         self.private_ip_allocation_method = None
         self.load_balancer = None
-        self.load_balancer_backend_pool = None 
+        self.load_balancer_backend_pool = None
         self.public_ip_address_name = None
         self.state = None
         self.subnet_name = None
@@ -400,9 +402,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
             if self.security_group_name:
                 nsg = self.get_security_group(self.security_group_name)
-                
-            if  self.load_balancer and self.load_balancer_backend_pool:  ##
-                lbpool = self.get_load_balancer_backend_pool(self.load_balancer, self.load_balancer_backend_pool)  ##
+
+            if self.load_balancer and self.load_balancer_backend_pool:
+                lbpool = self.get_load_balancer_backend_pool(self.load_balancer, self.load_balancer_backend_pool)  # #
 
         try:
             self.log('Fetching network interface {0}'.format(self.name))
@@ -453,14 +455,12 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                         results['ip_configuration']['subnet']['id'] = subnet.id
                         results['ip_configuration']['subnet']['name'] = subnet.name
                         results['ip_configuration']['subnet']['virtual_network_name'] = self.virtual_network_name
-                        
 
-                if self.load_balancer and self.load_balancer_backend_pool:  ##
+                if self.load_balancer and self.load_balancer_backend_pool:  # #
                     if results['ip_configuration']['load_balancer_pool'].get('id') != lbpool.id:
                         changed = True
                         self.log("CHANGED: network interface {0} load_balancer backend pool".format(self.name))
                         results['ip_configuration']['load_balancer_pool']['id'] = lbpool.id
-                        
 
             elif self.state == 'absent':
                 self.log("CHANGED: network interface {0} exists but requested state is 'absent'".format(self.name))
@@ -498,7 +498,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     if not pip and self.public_ip:
                         # create a default public_ip
                         pip = self.create_default_pip(self.resource_group, self.location, self.name,
-                                                            self.public_ip_allocation_method)
+                                                      self.public_ip_allocation_method)
 
                     nic = NetworkInterface(
                         location=self.location,
@@ -509,7 +509,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                             )
                         ]
                     )
-                    #nic.name = self.name
+                    # nic.name = self.name
                     nic.ip_configurations[0].subnet = Subnet(id=subnet.id)
                     nic.ip_configurations[0].name = 'default'
                     # add load balancer backend address pools
@@ -534,8 +534,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                         tags=results['tags'],
                         ip_configurations=[
                             NetworkInterfaceIPConfiguration(
-                                private_ip_allocation_method=
-                                results['ip_configuration']['private_ip_allocation_method']
+                                private_ip_allocation_method=results['ip_configuration']['private_ip_allocation_method']
                             )
                         ]
                     )
@@ -544,9 +543,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                     nic.ip_configurations[0].subnet = Subnet(id=subnet.id)
                     nic.ip_configurations[0].name = results['ip_configuration']['name']
                     if results['ip_configuration'].get('load_balancer_pool'):
-                        nic.ip_configurations[0].load_balancer_backend_address_pools = [lbpool]  ##
+                        nic.ip_configurations[0].load_balancer_backend_address_pools = [lbpool]  # #
 
-                    #nic.name = name=results['name'],
+                    # nic.name = name=results['name'],
                     if results['ip_configuration'].get('private_ip_address'):
                         nic.ip_configurations[0].private_ip_address = results['ip_configuration']['private_ip_address']
 
@@ -557,7 +556,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                             id=pip.id,
                             location=pip.location,
                             resource_guid=pip.resource_guid)
-                    #name=pip.name,
+                    # name=pip.name,
 
                     if results['network_security_group'].get('id'):
                         nsg = self.get_security_group(results['network_security_group']['name'])
@@ -609,9 +608,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         try:
             subnet = self.network_client.subnets.get(self.subnet_resource_group, vnet_name, subnet_name)
         except Exception as exc:
-            self.fail("Error: fetching subnet {0} in virtual network {1} - {2}".format(subnet_name,
-                                                                                      vnet_name,
-                                                                                      str(exc)))
+            self.fail("Error: fetching subnet {0} in virtual network {1} - {2}".format(subnet_name, vnet_name, str(exc)))
         return subnet
 
     def get_security_group(self, name):
@@ -629,8 +626,9 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             lb_pool_id = self.network_client.load_balancer_backend_address_pools.get(self.resource_group, load_balancer, load_balancer_backend_pool).id
             lbpool = BackendAddressPool(id=lb_pool_id)
         except Exception as exc:
-            self.fail("Error: creating load balancer backend {0} - {1}.".format(pool, str(exc)))
+            self.fail("Error: creating load balancer backend {0} - {1}.".format(lb_pool_id, str(exc)))
         return lbpool
+
 
 def main():
     AzureRMNetworkInterface()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
1. Support creating Azure network interface using subnet from a different resource group (Fixes #29607);
2. Support load balancer backend address pool. (mentioned in #2586)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/home/raymond/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
EXAMPLES = '''
    - name: Create a network interface in a resource_group with the subnet from a different resource group and a load balancer backend pool.
      azure_rm_networkinterface:
            name: nic001
            resource_group: Testing
            subnet_resource_group: Testing2
            virtual_network_name: vnet001
            subnet_name: subnet001
            load_balancer: loadbalancer001
            load_balancer_backend_pool: backend001
